### PR TITLE
キャンペーン作成削除時の通知にGroupIDを追加する

### DIFF
--- a/manager/interface/controllers/delivery_start_test.go
+++ b/manager/interface/controllers/delivery_start_test.go
@@ -27,6 +27,7 @@ func TestDeliveryStart_Execute(t *testing.T) {
 	createCampaign := func(id int, status string) *models.Campaign {
 		return &models.Campaign{
 			ID:        id,
+			GroupID:   1,
 			Status:    status,
 			StartAt:   time.Time{},
 			UpdatedAt: time.Time{},
@@ -158,7 +159,7 @@ func TestDeliveryStart_Execute(t *testing.T) {
 			gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(campaigns[0]), codes.StatusWarmup).Return(1, nil).Times(1)
 		tx.EXPECT().Commit().Return(nil).Times(1)
 		deliveryControlEvent.EXPECT().PublishCampaignEvent(
-			gomock.Eq(ctx), gomock.Eq(campaigns[0].ID), gomock.Eq(campaigns[0].OrgCode),
+			gomock.Eq(ctx), gomock.Eq(campaigns[0].ID), gomock.Eq(campaigns[0].GroupID), gomock.Eq(campaigns[0].OrgCode),
 			gomock.Eq("configured"), gomock.Eq("warmup"), gomock.Eq(""),
 		).Times(1)
 		deliveryStartUsecase.EXPECT().Reserve(gomock.Eq(ctx), gomock.Eq(campaigns[0].StartAt), gomock.Eq(campaigns[0])).Return().Times(1)
@@ -240,7 +241,7 @@ func TestDeliveryStart_Execute(t *testing.T) {
 			gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(campaigns[0]), gomock.Eq(codes.StatusWarmup)).Return(1, nil).Times(1)
 		tx.EXPECT().Commit().Return(nil).Times(1)
 		deliveryControlEvent.EXPECT().PublishCampaignEvent(
-			gomock.Eq(ctx), gomock.Eq(campaigns[0].ID), gomock.Eq(campaigns[0].OrgCode),
+			gomock.Eq(ctx), gomock.Eq(campaigns[0].ID), gomock.Eq(campaigns[0].GroupID), gomock.Eq(campaigns[0].OrgCode),
 			gomock.Eq("configured"), gomock.Eq("warmup"), gomock.Eq(""),
 		).Times(1)
 		deliveryStartUsecase.EXPECT().Reserve(gomock.Eq(ctx), gomock.Eq(campaigns[0].StartAt), campaigns[0]).Return().Times(1)

--- a/manager/mock/usecase/delivery_control_event.go
+++ b/manager/mock/usecase/delivery_control_event.go
@@ -36,15 +36,15 @@ func (m *MockDeliveryControlEvent) EXPECT() *MockDeliveryControlEventMockRecorde
 }
 
 // PublishCampaignEvent mocks base method.
-func (m *MockDeliveryControlEvent) PublishCampaignEvent(ctx context.Context, CampaignID int, organization, before, after, detail string) {
+func (m *MockDeliveryControlEvent) PublishCampaignEvent(ctx context.Context, CampaignID, groupID int, organization, before, after, detail string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PublishCampaignEvent", ctx, CampaignID, organization, before, after, detail)
+	m.ctrl.Call(m, "PublishCampaignEvent", ctx, CampaignID, groupID, organization, before, after, detail)
 }
 
 // PublishCampaignEvent indicates an expected call of PublishCampaignEvent.
-func (mr *MockDeliveryControlEventMockRecorder) PublishCampaignEvent(ctx, CampaignID, organization, before, after, detail interface{}) *gomock.Call {
+func (mr *MockDeliveryControlEventMockRecorder) PublishCampaignEvent(ctx, CampaignID, groupID, organization, before, after, detail interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishCampaignEvent", reflect.TypeOf((*MockDeliveryControlEvent)(nil).PublishCampaignEvent), ctx, CampaignID, organization, before, after, detail)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishCampaignEvent", reflect.TypeOf((*MockDeliveryControlEvent)(nil).PublishCampaignEvent), ctx, CampaignID, groupID, organization, before, after, detail)
 }
 
 // PublishCreativeEvent mocks base method.

--- a/manager/usecase/delivery_control_event_test.go
+++ b/manager/usecase/delivery_control_event_test.go
@@ -42,6 +42,7 @@ func TestDeliveryControlEvent_Publish(t *testing.T) {
 			Source:  "touchgift-job-manager",
 			OrgCode: "org1",
 			ID:      "1",
+			GroupID: "1",
 		}
 		_, err := json.Marshal(&deliveryControlEvent)
 		if err != nil {
@@ -58,7 +59,7 @@ func TestDeliveryControlEvent_Publish(t *testing.T) {
 		)
 
 		deliveryControlEventUsecase := NewDeliveryControlEvent(logger, notificationHandler)
-		deliveryControlEventUsecase.PublishCampaignEvent(ctx, 1, "org1", "configured", "warmup", "")
+		deliveryControlEventUsecase.PublishCampaignEvent(ctx, 1, 1, "org1", "configured", "warmup", "")
 	})
 
 	t.Run("通知に失敗した場合は専用のエラーログを出力する", func(t *testing.T) {
@@ -83,6 +84,7 @@ func TestDeliveryControlEvent_Publish(t *testing.T) {
 			Source:  "touchgift-job-manager",
 			OrgCode: "org1",
 			ID:      "1",
+			GroupID: "1",
 		}
 		_, err := json.Marshal(&deliveryControlEvent)
 		if err != nil {
@@ -99,7 +101,7 @@ func TestDeliveryControlEvent_Publish(t *testing.T) {
 
 		// テストを実行する
 		deliveryControlEventUsecase := NewDeliveryControlEvent(logger, notificationHandler)
-		deliveryControlEventUsecase.PublishCampaignEvent(ctx, 1, "org1", "warmup", "started", "")
+		deliveryControlEventUsecase.PublishCampaignEvent(ctx, 1, 1, "org1", "warmup", "started", "")
 	})
 }
 
@@ -118,6 +120,7 @@ func TestDeliveryControlEvent_createCampaignCacheLog(t *testing.T) {
 		notificationHandler := mock_notification.NewMockNotificationHandler(ctrl)
 
 		CampaignID := 1
+		groupID := 2
 		organization := "org"
 		cache := "NONE"
 		before := "configured"
@@ -128,9 +131,10 @@ func TestDeliveryControlEvent_createCampaignCacheLog(t *testing.T) {
 		deliveryControlEventUsecase := NewDeliveryControlEvent(logger, notificationHandler)
 		// private methodのテストを行うためにcastする
 		deliveryControlEventInteractor := deliveryControlEventUsecase.(*deliveryControlEvent)
-		actual := deliveryControlEventInteractor.createCampaignCacheLog(CampaignID, organization, before, after, codes.DetailShortage)
+		actual := deliveryControlEventInteractor.createCampaignCacheLog(CampaignID, groupID, organization, before, after, codes.DetailShortage)
 		assert.NotEmpty(t, actual.TraceID)
 		assert.Equal(t, strconv.Itoa(CampaignID), actual.ID)
+		assert.Equal(t, strconv.Itoa(groupID), actual.GroupID)
 		assert.Equal(t, organization, actual.OrgCode)
 		assert.Equal(t, expectedEvent, actual.Event)
 		assert.Equal(t, cache, actual.Action)

--- a/manager/usecase/delivery_end.go
+++ b/manager/usecase/delivery_end.go
@@ -266,7 +266,7 @@ func (d *deliveryEnd) end(ctx context.Context, startTime time.Time, reservedData
 		return errors.Wrap(err, "Failed to commit")
 	}
 	// 配信制御イベントを発行する
-	d.deliveryControlEvent.PublishCampaignEvent(ctx, deliveryData.ID, deliveryData.OrgCode, deliveryData.Status, *afterStatus, "")
+	d.deliveryControlEvent.PublishCampaignEvent(ctx, deliveryData.ID, deliveryData.GroupID, deliveryData.OrgCode, deliveryData.Status, *afterStatus, "")
 	return nil
 }
 

--- a/manager/usecase/delivery_end_test.go
+++ b/manager/usecase/delivery_end_test.go
@@ -415,7 +415,7 @@ func TestDeliveryEnd_Execute_DeliveryEnd(t *testing.T) {
 		}
 		groupIDStr := strconv.Itoa(deliveryData.GroupID)
 		touchPointID := "test"
-		touchPoints := []*models.TouchPoint{{ID: touchPointID}}
+		touchPoints := []*models.TouchPoint{{ID: touchPointID, GroupID: deliveryData.GroupID}}
 		// 何回呼ばれるか (Times)
 		// を定義する
 		gomock.InOrder(
@@ -430,7 +430,7 @@ func TestDeliveryEnd_Execute_DeliveryEnd(t *testing.T) {
 			deliveryControlUsecase.EXPECT().PublishDeliveryEvent(gomock.Eq(ctx), gomock.Eq(touchPointID), gomock.Eq(deliveryData.GroupID), gomock.Eq(deliveryData.ID), gomock.Eq(deliveryData.OrgCode), gomock.Eq("DELETE")),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlUsecase.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(deliveryData.ID), gomock.Eq(deliveryData.OrgCode), gomock.Eq(deliveryData.Status), gomock.Eq(status), gomock.Eq(""),
+				gomock.Eq(ctx), gomock.Eq(deliveryData.ID), gomock.Eq(deliveryData.GroupID), gomock.Eq(deliveryData.OrgCode), gomock.Eq(deliveryData.Status), gomock.Eq(status), gomock.Eq(""),
 			),
 		)
 
@@ -489,7 +489,7 @@ func TestDeliveryEnd_Execute_DeliveryEnd(t *testing.T) {
 			campaignRepository.EXPECT().GetDeliveryCampaignCountByGroupID(gomock.Eq(ctx), gomock.Eq(deliveryData.GroupID)).Return(1, nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlUsecase.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(deliveryData.ID), gomock.Eq(deliveryData.OrgCode), gomock.Eq(deliveryData.Status), gomock.Eq(status), gomock.Eq(""),
+				gomock.Eq(ctx), gomock.Eq(deliveryData.ID), gomock.Eq(deliveryData.GroupID), gomock.Eq(deliveryData.OrgCode), gomock.Eq(deliveryData.Status), gomock.Eq(status), gomock.Eq(""),
 			),
 		)
 
@@ -942,6 +942,7 @@ func TestDeliveryEnd_Execute_DeliveryEnd(t *testing.T) {
 func createEndTestCampaign(campaign *models.Campaign, startAt time.Time, endAt sql.NullTime, status string, updatedAt time.Time) *models.Campaign {
 	return &models.Campaign{
 		ID:        campaign.ID,
+		GroupID:   1,
 		Status:    status,
 		StartAt:   startAt,
 		EndAt:     endAt,

--- a/manager/usecase/delivery_operation.go
+++ b/manager/usecase/delivery_operation.go
@@ -87,7 +87,7 @@ func (d *deliveryOperation) Process(ctx context.Context, current time.Time, camp
 				return err
 			}
 			// 配信制御イベントを発行する
-			d.deliveryControlEvent.PublishCampaignEvent(ctx, campaign.ID, campaign.OrgCode, *beforeStatus, *afterStatus, "")
+			d.deliveryControlEvent.PublishCampaignEvent(ctx, campaign.ID, campaign.GroupID, campaign.OrgCode, *beforeStatus, *afterStatus, "")
 		}
 	case "delete":
 		// キャンペーンの物理削除は配信後には起きないためdelivery_data削除はしない

--- a/manager/usecase/delivery_operation_test.go
+++ b/manager/usecase/delivery_operation_test.go
@@ -122,7 +122,7 @@ func TestDeliveryOperation_Process_Sync_StoreDelivery_DuringDelivery(t *testing.
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&campaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(after), gomock.Eq(""),
 			),
 		)
@@ -180,7 +180,7 @@ func TestDeliveryOperation_Process_Sync_StoreDelivery_DuringDelivery(t *testing.
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&campaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(codes.StatusStarted), gomock.Eq(""),
 			),
 		)
@@ -234,7 +234,7 @@ func TestDeliveryOperation_Process_Sync_StoreDelivery_DuringDelivery(t *testing.
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&campaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(codes.StatusStarted), gomock.Eq(""),
 			),
 		)
@@ -289,7 +289,7 @@ func TestDeliveryOperation_Process_Sync_StoreDelivery_DuringDelivery(t *testing.
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&CampaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(codes.StatusStarted), gomock.Eq(""),
 			),
 		)
@@ -355,7 +355,7 @@ func TestDeliveryOperation_Process_Sync_DeleteDelivery(t *testing.T) {
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&CampaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(after), gomock.Eq(""),
 			),
 		)
@@ -414,7 +414,7 @@ func TestDeliveryOperation_Process_Sync_DeleteDelivery(t *testing.T) {
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&CampaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(after), gomock.Eq(""),
 			),
 		)
@@ -477,7 +477,7 @@ func TestDeliveryOperation_Process_Sync_EndedDelivery(t *testing.T) {
 			creativeUsecase.EXPECT().Process(gomock.Eq(ctx), gomock.Eq(tx), gomock.Eq(current), gomock.Eq(&CampaignLog.Creatives)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEvent.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
+				gomock.Eq(ctx), gomock.Eq(campaign.ID), gomock.Eq(campaign.GroupID), gomock.Eq(campaign.OrgCode), gomock.Eq(campaign.Status),
 				gomock.Eq(status), gomock.Eq(""),
 			),
 		)

--- a/manager/usecase/delivery_start.go
+++ b/manager/usecase/delivery_start.go
@@ -235,7 +235,7 @@ func (d *deliveryStart) start(
 	}
 	// 配信制御イベントを発行する
 	d.deliveryControlEvent.PublishCampaignEvent(
-		ctx, startCampaign.ID, startCampaign.OrgCode, startCampaign.Status, codes.StatusStarted, "")
+		ctx, startCampaign.ID, startCampaign.GroupID, startCampaign.OrgCode, startCampaign.Status, codes.StatusStarted, "")
 	return nil
 }
 

--- a/manager/usecase/delivery_start_test.go
+++ b/manager/usecase/delivery_start_test.go
@@ -497,7 +497,7 @@ func TestDeliveryStart_Execute_DeliveryStart(t *testing.T) {
 			contentDataRepository.EXPECT().Put(gomock.Eq(ctx), gomock.Eq(contentData)).Return(nil),
 			tx.EXPECT().Commit().Return(nil),
 			deliveryControlEventUsecase.EXPECT().PublishCampaignEvent(
-				gomock.Eq(ctx), gomock.Eq(deliveryData[0].ID), gomock.Eq(deliveryData[0].OrgCode), gomock.Eq(deliveryData[0].Status),
+				gomock.Eq(ctx), gomock.Eq(deliveryData[0].ID), gomock.Eq(deliveryData[0].GroupID), gomock.Eq(deliveryData[0].OrgCode), gomock.Eq(deliveryData[0].Status),
 				gomock.Eq(codes.StatusStarted), gomock.Eq(""),
 			),
 		)


### PR DESCRIPTION
ローカルでの通知時のログ
```
{"level":"info","ev":"application","message_id":"ef5565d8-fd59-46cb-bd78-1e94488e0287","trace_id":"crpql86f0ftuu8ltthsg","trace_time":"2024-09-25T15:16:00.029149+09:00","version":1,"event":"end","event_detail":"","action":"DELETE","source":"touchgift-job-manager","org_code":"org_1","campaign_id":"1","group_id":"1","time":1727244960,"caller":"/Users/naoyukigoko/touchgift-job/manager/usecase/delivery_control_event.go:69","message":"Publish campaign cache event"}
```