### PR TITLE
content_dataのgimmickをmapで作成する

### DIFF
--- a/manager/domain/models/delivery.go
+++ b/manager/domain/models/delivery.go
@@ -52,7 +52,7 @@ type DeliveryDataCreative struct {
 type DeliveryDataContent struct {
 	CampaignID string               `json:"campaign_id"`
 	Coupons    []DeliveryCouponData `json:"coupons"`
-	Gimmicks   []Gimmick            `json:"gimmicks"`
+	Gimmicks   Gimmick              `json:"gimmicks"`
 }
 
 type DeliveryCouponData struct {

--- a/manager/infra/delivery_data_content_repository_test.go
+++ b/manager/infra/delivery_data_content_repository_test.go
@@ -36,7 +36,7 @@ func TestContentDataRepository_Get(t *testing.T) {
 		expected := models.DeliveryDataContent{
 			CampaignID: ID,
 			Coupons:    []models.DeliveryCouponData{{ID: 1}},
-			Gimmicks:   []models.Gimmick{{URL: &URL}},
+			Gimmicks:   models.Gimmick{URL: &URL},
 		}
 		// データを用意
 		if err := contentDataRepository.Put(ctx, &expected); !assert.NoError(t, err) {
@@ -70,7 +70,7 @@ func TestContentDataRepository_Put(t *testing.T) {
 		return &models.DeliveryDataContent{
 			CampaignID: campaignID,
 			Coupons:    []models.DeliveryCouponData{{ID: 1}},
-			Gimmicks:   []models.Gimmick{{URL: &URL}},
+			Gimmicks:   models.Gimmick{URL: &URL},
 		}
 	}
 
@@ -137,12 +137,12 @@ func TestContentDataRepository_PutAll(t *testing.T) {
 			{
 				CampaignID: "1",
 				Coupons:    []models.DeliveryCouponData{{ID: 1}},
-				Gimmicks:   []models.Gimmick{{URL: &URL}},
+				Gimmicks:   models.Gimmick{URL: &URL},
 			},
 			{
 				CampaignID: "2",
 				Coupons:    []models.DeliveryCouponData{{ID: 2}},
-				Gimmicks:   []models.Gimmick{{URL: &URL}},
+				Gimmicks:   models.Gimmick{URL: &URL},
 			},
 		}
 	}
@@ -227,7 +227,7 @@ func TestContentDataRepository_Delete(t *testing.T) {
 		expected := models.DeliveryDataContent{
 			CampaignID: ID,
 			Coupons:    []models.DeliveryCouponData{{ID: 1}},
-			Gimmicks:   []models.Gimmick{{URL: &URL}},
+			Gimmicks:   models.Gimmick{URL: &URL},
 		}
 		if err := contentDataRepository.Put(ctx, &expected); !assert.NoError(t, err) {
 			return

--- a/manager/usecase/delivery_start.go
+++ b/manager/usecase/delivery_start.go
@@ -305,11 +305,9 @@ func (d *deliveryStart) getDataFromRDB(ctx context.Context, tx repository.Transa
 	content := &models.DeliveryDataContent{
 		CampaignID: strconv.Itoa(campaign.ID),
 		Coupons:    deliveryCouponDatas,
-		Gimmicks: []models.Gimmick{
-			{
-				URL:  gimmickURL,
-				Code: gimmickCode,
-			},
+		Gimmicks: models.Gimmick{
+			URL:  gimmickURL,
+			Code: gimmickCode,
 		},
 	}
 	// touchPoint作成

--- a/manager/usecase/delivery_start_test.go
+++ b/manager/usecase/delivery_start_test.go
@@ -435,7 +435,7 @@ func TestDeliveryStart_Execute_DeliveryStart(t *testing.T) {
 	contentData := &models.DeliveryDataContent{
 		CampaignID: strconv.Itoa(campaignData.ID),
 		Coupons:    []models.DeliveryCouponData{{ID: 1}},
-		Gimmicks:   []models.Gimmick{{URL: &gimmickURL, Code: &gimmickCode}},
+		Gimmicks:   models.Gimmick{URL: &gimmickURL, Code: &gimmickCode},
 	}
 	// DBから取得するデータの条件
 	contentCondition := repository.ContentByCampaignIDCondition{CampaignID: campaignData.ID}


### PR DESCRIPTION
**対応内容**
タイトル通り

**動作確認**
ローカルでテストデータが配信開始した際にgimmickがmapで確認されることを確認
```
// RDBにテストデータを作成
$ make create-db-testdata
AWS_PROFILE=dummy go test -v ./infra -run TestData -tags=createdata -count 1
=== RUN   TestData
{"level":"info","ev":"application","time":1727253939,"caller":"/Users/naoyukigoko/touchgift-job/manager/infra/sql_handler.go:47","message":"Connect database"}
--- PASS: TestData (0.06s)
PASS
ok      touchgift-job-manager/infra     0.968s

// 配信開始した際Dynamoに作成されたデータ
$ make get-content
aws dynamodb scan --table-name touchgift_content_data --endpoint-url http://localhost:4566 --profile dummy
{
    "Items": [
        {
            "gimmicks": {
                "M": {
                    "gimmick_code": {
                        "S": "code1"
                    },
                    "gimmick_url": {
                        "S": "http://example.com"
                    }
                }
            },
            "coupons": {
                "L": [
                    {
                        "M": {
                            "name": {
                                "S": "coupon1"
                            },
                            "code": {
                                "S": "code1"
                            },
                            "id": {
                                "N": "4"
                            },
                            "rate": {
                                "N": "100"
                            },
                            "image_url": {
                                "S": "http://example.com"
                            }
                        }
                    }
                ]
            },
            "campaign_id": {
                "S": "13"
            }
        },
        {
            "gimmicks": {
                "M": {
                    "gimmick_url": {
                        "S": "URL"
                    }
                }
            },
            "coupons": {
                "L": [
                    {
                        "M": {
                            "name": {
                                "NULL": true
                            },
                            "code": {
                                "NULL": true
                            },
                            "id": {
                                "N": "2"
                            },
                            "rate": {
                                "N": "0"
                            },
                            "image_url": {
                                "NULL": true
                            }
                        }
                    }
                ]
            },
            "campaign_id": {
                "S": "2"
            }
        }
    ],
    "Count": 2,
    "ScannedCount": 2,
    "ConsumedCapacity": null
}
```