### PR TITLE
touchgift_delivery_dataテーブルにいれる値の修正

### DIFF
--- a/manager/domain/models/delivery.go
+++ b/manager/domain/models/delivery.go
@@ -27,6 +27,7 @@ func (d *DeliveryDataCampaign) CreateCampaign() *Campaign {
 
 type DeliveryTouchPoint struct {
 	GroupID int    `json:"group_id"`
+	StoreID string `json:"store_id"`
 	ID      string `json:"id"`
 }
 

--- a/manager/domain/models/delivery_control_log.go
+++ b/manager/domain/models/delivery_control_log.go
@@ -33,6 +33,7 @@ type CreativeCacheLog struct {
 type DeliveryCacheLog struct {
 	ID         string `json:"id"`
 	GroupID    int    `json:"group_id"`
+	StoreID    string `json:"store_id"`
 	Action     string `json:"action"` // PUT or DELETE
 	OrgCode    string `json:"org_code"`
 	CampaignID int    `json:"campaign_id"`

--- a/manager/domain/models/touch_point.go
+++ b/manager/domain/models/touch_point.go
@@ -2,5 +2,6 @@ package models
 
 type TouchPoint struct {
 	GroupID int    `db:"group_id" json:"group_id"`
+	StoreID string `db:"store_id" json:"store_id"`
 	ID      string `db:"id" json:"id"`
 }

--- a/manager/infra/touch_point_repository.go
+++ b/manager/infra/touch_point_repository.go
@@ -23,7 +23,8 @@ func (t *TouchPointRepository) GetTouchPointByGroupID(ctx context.Context,
 
 	query := `SELECT
 		c.store_group_id AS "group_id",
-		tp.point_unique_id AS "id"
+		tp.point_unique_id AS "id",
+		tp.store_id AS "store_id",
 	FROM campaign c
 	JOIN store_map sm on c.store_group_id = sm.store_group_id
 	JOIN store s on sm.store_id = s.id

--- a/manager/usecase/delivery_control_event.go
+++ b/manager/usecase/delivery_control_event.go
@@ -17,7 +17,7 @@ import (
 type DeliveryControlEvent interface {
 	PublishCampaignEvent(ctx context.Context, CampaignID int, groupID int, organization string, before string, after string, detail string)
 	PublishCreativeEvent(ctx context.Context, creative *models.DeliveryDataCreative, organization string, action string)
-	PublishDeliveryEvent(ctx context.Context, id string, groupID int, campaignID int, organization string, action string)
+	PublishDeliveryEvent(ctx context.Context, id string, groupID int, storeID string, campaignID int, organization string, action string)
 }
 
 type deliveryControlEvent struct {

--- a/manager/usecase/delivery_control_event.go
+++ b/manager/usecase/delivery_control_event.go
@@ -102,8 +102,8 @@ func (d *deliveryControlEvent) PublishCreativeEvent(ctx context.Context,
 
 // サーバーのTouchpointキャッシュ更新のためSNSへPublishを行う
 func (d *deliveryControlEvent) PublishDeliveryEvent(ctx context.Context,
-	id string, groupID int, campaignID int, organization string, operation string) {
-	deliveryControl := d.createDeliveryEventLog(id, groupID, organization, campaignID, operation)
+	id string, groupID int, storeID string, campaignID int, organization string, operation string) {
+	deliveryControl := d.createDeliveryEventLog(id, groupID, storeID, organization, campaignID, operation)
 
 	message, err := json.Marshal(deliveryControl)
 	if err != nil {
@@ -128,6 +128,7 @@ func (d *deliveryControlEvent) PublishDeliveryEvent(ctx context.Context,
 			Str("org_code", deliveryControl.OrgCode).
 			Int("campaign_id", deliveryControl.CampaignID).
 			Int("group_id", deliveryControl.GroupID).
+			Str("store_id", deliveryControl.StoreID).
 			Msg("Publish delivery control event")
 	}
 }
@@ -188,13 +189,14 @@ func (d *deliveryControlEvent) createCreativeEventLog(creative *models.DeliveryD
 	}
 }
 
-func (d *deliveryControlEvent) createDeliveryEventLog(id string, groupID int,
+func (d *deliveryControlEvent) createDeliveryEventLog(id string, groupID int, storeID string,
 	organization string, campaignID int, operation string) *models.DeliveryCacheLog {
 
 	return &models.DeliveryCacheLog{
 		Action:     operation,
 		OrgCode:    organization,
 		ID:         id,
+		StoreID:    storeID,
 		GroupID:    groupID,
 		CampaignID: campaignID,
 	}

--- a/manager/usecase/delivery_end.go
+++ b/manager/usecase/delivery_end.go
@@ -191,7 +191,7 @@ func (d *deliveryEnd) Delete(ctx context.Context, campaign *models.Campaign) err
 			if err := d.touchPointDataRepository.Delete(ctx, &touchPoint.ID, &groupIDStr); err != nil {
 				return err
 			}
-			d.deliveryControlEvent.PublishDeliveryEvent(ctx, touchPoint.ID, touchPoint.GroupID, campaign.ID, campaign.OrgCode, "DELETE")
+			d.deliveryControlEvent.PublishDeliveryEvent(ctx, touchPoint.ID, touchPoint.GroupID, touchPoint.StoreID, campaign.ID, campaign.OrgCode, "DELETE")
 		}
 	}
 	return nil

--- a/manager/usecase/delivery_end_test.go
+++ b/manager/usecase/delivery_end_test.go
@@ -411,7 +411,7 @@ func TestDeliveryEnd_Execute_DeliveryEnd(t *testing.T) {
 		id := strconv.Itoa(deliveryData.ID)
 		touchPointCondition := repository.TouchPointByGroupIDCondition{
 			GroupID: deliveryData.GroupID,
-			Limit:   100000,
+			Limit:   1000000,
 		}
 		groupIDStr := strconv.Itoa(deliveryData.GroupID)
 		touchPointID := "test"

--- a/manager/usecase/delivery_start.go
+++ b/manager/usecase/delivery_start.go
@@ -295,7 +295,7 @@ func (d *deliveryStart) getDataFromRDB(ctx context.Context, tx repository.Transa
 	// タッチポイントの取得
 	touchPointCondition := &repository.TouchPointByGroupIDCondition{
 		GroupID: campaign.GroupID,
-		Limit:   1,
+		Limit:   1000000,
 	}
 	touchPoints, err := d.touchPointRepository.GetTouchPointByGroupID(ctx, touchPointCondition)
 	if err != nil {
@@ -316,6 +316,7 @@ func (d *deliveryStart) getDataFromRDB(ctx context.Context, tx repository.Transa
 		touchPointData := models.DeliveryTouchPoint{
 			ID:      touchPoint.ID,
 			GroupID: touchPoint.GroupID,
+			StoreID: touchPoint.StoreID,
 		}
 		touchPointDatas = append(touchPointDatas, &touchPointData)
 	}
@@ -335,7 +336,7 @@ func (d *deliveryStart) createDeliveryDatas(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		d.deliveryControlEvent.PublishDeliveryEvent(ctx, tp.ID, tp.GroupID, campaign.ID, campaign.OrgCode, "PUT")
+		d.deliveryControlEvent.PublishDeliveryEvent(ctx, tp.ID, tp.GroupID, tp.StoreID, campaign.ID, campaign.OrgCode, "PUT")
 	}
 
 	for _, creative := range creatives {


### PR DESCRIPTION
## 概要
* キャンペーン開始時にDynamoDBのtouchgift_delivery_dataテーブルにNFC情報がすべて入るはずが、現状1件しか登録されない問題の修正
* 合わせて、store_idもdeliveryテーブルに入るように修正